### PR TITLE
Fix cffi compilation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asn1crypto==0.24.0
 certifi==2018.10.15
-cffi==1.11.5
+cffi==1.14.5
 cryptography==2.3.1
 future==0.17.1
 idna==2.7


### PR DESCRIPTION
On some OSs (Ubuntu 20.04 in @siaarzh case) cffi will fail to compile.
Installing dev packages did nothing, but bumping cffi version did the trick.